### PR TITLE
fix the issue of components should be required field on crypto-keypath

### DIFF
--- a/src/main/java/com/sparrowwallet/hummingbird/registry/CryptoKeypath.java
+++ b/src/main/java/com/sparrowwallet/hummingbird/registry/CryptoKeypath.java
@@ -62,9 +62,7 @@ public class CryptoKeypath extends RegistryItem {
             }
             componentArray.add(pathComponent.isHardened() ? SimpleValue.TRUE : SimpleValue.FALSE);
         }
-        if(!componentArray.getDataItems().isEmpty()) {
-            map.put(new UnsignedInteger(COMPONENTS_KEY), componentArray);
-        }
+        map.put(new UnsignedInteger(COMPONENTS_KEY), componentArray);
         if(sourceFingerprint != null) {
             map.put(new UnsignedInteger(SOURCE_FINGERPRINT_KEY), new UnsignedInteger(new BigInteger(1, sourceFingerprint)));
         }

--- a/src/test/java/com/sparrowwallet/hummingbird/registry/CryptoHDKeyTest.java
+++ b/src/test/java/com/sparrowwallet/hummingbird/registry/CryptoHDKeyTest.java
@@ -36,10 +36,29 @@ public class CryptoHDKeyTest {
         Assert.assertEquals("ced155c72456255881793514edc5bd9447e7f74abb88c6d6b6480fd016ee8c85", TestUtils.bytesToHex(cryptoHDKey.getChainCode()));
         Assert.assertEquals(cryptoHDKey.getUseInfo().getNetwork(), CryptoCoinInfo.Network.TESTNET);
         Assert.assertEquals("44'/1'/1'/0/1", cryptoHDKey.getOrigin().getPath());
+        Assert.assertNull(cryptoHDKey.getOrigin().getDepth());
         Assert.assertEquals("e9181cf3", TestUtils.bytesToHex(cryptoHDKey.getParentFingerprint()));
         Assert.assertNull(cryptoHDKey.getChildren());
         Assert.assertEquals(hex.toLowerCase(), TestUtils.encode(cryptoHDKey.toCbor()));
         String ur = "ur:crypto-hdkey/onaxhdclaojlvoechgferkdpqdiabdrflawshlhdmdcemtfnlrctghchbdolvwsednvdztbgolaahdcxtottgostdkhfdahdlykkecbbweskrymwflvdylgerkloswtbrpfdbsticmwylklpahtaadehoyaoadamtaaddyoyadlecsdwykadykadykaewkadwkaycywlcscewfihbdaehn";
+        Assert.assertEquals(ur, cryptoHDKey.toUR().toString());
+    }
+
+
+    @Test
+    public void testMasterPublicKey() throws CborException {
+        String hex = "A303582103AC3DF08EC59F6F1CDC55B3007F90F1A98435EC345C3CAC400EDE1DD533D75FA9045820E8145DB627E79188E14C1FD6C772998509961D358FE8ECF3D7CC43BB1D0F952006D90130A20180021A854BC782";
+        byte[] data = TestUtils.hexToBytes(hex);
+        List<DataItem> items = CborDecoder.decode(data);
+        CryptoHDKey cryptoHDKey = CryptoHDKey.fromCbor(items.get(0));
+        Assert.assertFalse(cryptoHDKey.isMaster());
+        Assert.assertFalse(cryptoHDKey.isPrivateKey());
+        Assert.assertEquals("03ac3df08ec59f6f1cdc55b3007f90f1a98435ec345c3cac400ede1dd533d75fa9", TestUtils.bytesToHex(cryptoHDKey.getKey()));
+        Assert.assertEquals("e8145db627e79188e14c1fd6c772998509961d358fe8ecf3d7cc43bb1d0f9520", TestUtils.bytesToHex(cryptoHDKey.getChainCode()));
+        Assert.assertNull(cryptoHDKey.getOrigin().getPath());
+        Assert.assertEquals("854bc782", TestUtils.bytesToHex(cryptoHDKey.getOrigin().getSourceFingerprint()));
+        Assert.assertEquals(hex.toLowerCase(), TestUtils.encode(cryptoHDKey.toCbor()));
+        String ur = "ur:crypto-hdkey/otaxhdclaxpsfswtmnsknejlceuogoqdaelbmhwnptlrecwpeehhfnpsfzbauecatleotsheptaahdcxvsbbhlrpdivdmelovygscttbstjpnllpasmtcaecmyvswpwftssffxrkcabsmdcxamtaaddyoeadlaaocylpgrstlfiewtseje";
         Assert.assertEquals(ur, cryptoHDKey.toUR().toString());
     }
 }

--- a/src/test/java/com/sparrowwallet/hummingbird/registry/CryptoOutputTest.java
+++ b/src/test/java/com/sparrowwallet/hummingbird/registry/CryptoOutputTest.java
@@ -80,7 +80,7 @@ public class CryptoOutputTest {
 
     @Test
     public void testMulti() throws CborException {
-        String hex = "d90191d90196a201010282d9012fa403582103cbcaa9c98c877a26977d00825c956a238e8dddfbd322cce4f74b0b5bd6ace4a704582060499f801b896d83179a4374aeb7822aaeaceaa0db1f85ee3e904c4defbd968906d90130a1030007d90130a1018601f400f480f4d9012fa403582102fc9e5af0ac8d9b3cecfe2a888e2117ba3d089d8585886c9c826b6b22a98d12ea045820f0909affaa7ee7abe5dd4e100598d4dc53cd709d5a5c2cac40e7412f232f7c9c06d90130a2018200f4021abd16bee507d90130a1018600f400f480f4";
+        String hex = "d90191d90196a201010282d9012fa403582103cbcaa9c98c877a26977d00825c956a238e8dddfbd322cce4f74b0b5bd6ace4a704582060499f801b896d83179a4374aeb7822aaeaceaa0db1f85ee3e904c4defbd968906d90130a20180030007d90130a1018601f400f480f4d9012fa403582102fc9e5af0ac8d9b3cecfe2a888e2117ba3d089d8585886c9c826b6b22a98d12ea045820f0909affaa7ee7abe5dd4e100598d4dc53cd709d5a5c2cac40e7412f232f7c9c06d90130a2018200f4021abd16bee507d90130a1018600f400f480f4";
         byte[] data = TestUtils.hexToBytes(hex);
         List<DataItem> items = CborDecoder.decode(data);
         CryptoOutput cryptoOutput = CryptoOutput.fromCbor(items.get(0));
@@ -107,7 +107,7 @@ public class CryptoOutputTest {
         Assert.assertNull(secondKey.getChildren().getSourceFingerprint());
 
         Assert.assertEquals(hex, TestUtils.encode(cryptoOutput.toCbor()));
-        String ur = "ur:crypto-output/taadmetaadmtoeadadaolftaaddloxaxhdclaxsbsgptsolkltkndsmskiaelfhhmdimcnmnlgutzotecpsfveylgrbdhptbpsveosaahdcxhnganelacwldjnlschnyfxjyplrllfdrplpswdnbuyctlpwyfmmhgsgtwsrymtldamtaaddyoyaxaeattaaddyoyadlnadwkaewklawktaaddloxaxhdclaoztnnhtwtpslgndfnwpzedrlomnclchrdfsayntlplplojznslfjejecpptlgbgwdaahdcxwtmhnyzmpkkbvdpyvwutglbeahmktyuogusnjonththhdwpsfzvdfpdlcndlkensamtaaddyoeadlfaewkaocyrycmrnvwattaaddyoyadlnaewkaewklawkkkztdlon";
+        String ur = "ur:crypto-output/taadmetaadmtoeadadaolftaaddloxaxhdclaxsbsgptsolkltkndsmskiaelfhhmdimcnmnlgutzotecpsfveylgrbdhptbpsveosaahdcxhnganelacwldjnlschnyfxjyplrllfdrplpswdnbuyctlpwyfmmhgsgtwsrymtldamtaaddyoeadlaaxaeattaaddyoyadlnadwkaewklawktaaddloxaxhdclaoztnnhtwtpslgndfnwpzedrlomnclchrdfsayntlplplojznslfjejecpptlgbgwdaahdcxwtmhnyzmpkkbvdpyvwutglbeahmktyuogusnjonththhdwpsfzvdfpdlcndlkensamtaaddyoeadlfaewkaocyrycmrnvwattaaddyoyadlnaewkaewklawktdbsfttn";
         Assert.assertEquals(ur, cryptoOutput.toUR().toString());
     }
 }


### PR DESCRIPTION
Based on the definition of Crypto-keypath the components is a required field even it is empty, this PR is to fix this issue

https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-007-hdkey.md