### PR TITLE
Fixed typo in CryptoCoin info key

### DIFF
--- a/src/main/java/com/sparrowwallet/hummingbird/registry/RegistryType.java
+++ b/src/main/java/com/sparrowwallet/hummingbird/registry/RegistryType.java
@@ -16,7 +16,7 @@ public enum RegistryType {
     CRYPTO_BIP39("crypto-bip39", 301, CryptoBip39.class),
     CRYPTO_HDKEY("crypto-hdkey", 303, CryptoHDKey.class),
     CRYPTO_KEYPATH("crypto-keypath", 304, CryptoKeypath.class),
-    CRYPTO_COIN_INFO("crypto-coin-info", 305, CryptoCoinInfo.class),
+    CRYPTO_COIN_INFO("crypto-coininfo", 305, CryptoCoinInfo.class),
     CRYPTO_ECKEY("crypto-eckey", 306, CryptoECKey.class),
     CRYPTO_ADDRESS("crypto-address", 307, CryptoAddress.class),
     CRYPTO_OUTPUT("crypto-output", 308, CryptoOutput.class),


### PR DESCRIPTION
Fixed typo in CryptoCoin info key according to:
https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-007-hdkey.md#cddl-for-coin-info

This is not a big deal in order to convert from/to CBOR but in terms of different platform compatibility, this will cause issues when trying to import an UR string from a different source.

`./gradlew test`
```
BUILD SUCCESSFUL in 5s
3 actionable tasks: 3 executed

```