### PR TITLE
CryptoCoinInfo crash fix

### DIFF
--- a/src/main/java/com/sparrowwallet/hummingbird/registry/CryptoCoinInfo.java
+++ b/src/main/java/com/sparrowwallet/hummingbird/registry/CryptoCoinInfo.java
@@ -17,12 +17,12 @@ public class CryptoCoinInfo extends RegistryItem {
     }
 
     public CryptoCoinInfo(Type type, Network network) {
-        this.type = (type != null ? type.ordinal() : null);
+        this.type = (type != null ? type.typeValue : null);
         this.network = (network != null ? network.ordinal() : null);
     }
 
     public Type getType() {
-        return type == null ? Type.BITCOIN : Type.values()[type];
+        return type == null ? Type.BITCOIN : Type.getTypeFromValue(type);
     }
 
     public Network getNetwork() {
@@ -65,7 +65,23 @@ public class CryptoCoinInfo extends RegistryItem {
     }
 
     public enum Type {
-        BITCOIN
+        BITCOIN(0), ETHEREUM(60);
+
+        Integer typeValue;
+
+        Type(Integer typeValue) {
+            this.typeValue = typeValue;
+        }
+
+        static Type getTypeFromValue(int value) {
+            for (int i = 0; i < Type.values().length; i++) {
+                Type current = Type.values()[i];
+                if(value == current.typeValue) {
+                    return current;
+                }
+            }
+            return null;
+        }
     }
 
     public enum Network {

--- a/src/test/java/com/sparrowwallet/hummingbird/registry/CryptoCoinInfoTest.java
+++ b/src/test/java/com/sparrowwallet/hummingbird/registry/CryptoCoinInfoTest.java
@@ -1,0 +1,25 @@
+package com.sparrowwallet.hummingbird.registry;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CryptoCoinInfoTest {
+
+    @Test
+    public void testBitcoinCoinInfo() {
+        CryptoCoinInfo coinInfo = new CryptoCoinInfo(CryptoCoinInfo.Type.BITCOIN, CryptoCoinInfo.Network.MAINNET);
+        Assert.assertSame(coinInfo.getType().typeValue, CryptoCoinInfo.Type.BITCOIN.typeValue);
+    }
+
+    @Test
+    public void testEthereumCoinInfo() {
+        CryptoCoinInfo coinInfo = new CryptoCoinInfo(CryptoCoinInfo.Type.ETHEREUM, CryptoCoinInfo.Network.MAINNET);
+        Assert.assertSame(coinInfo.getType().typeValue, CryptoCoinInfo.Type.ETHEREUM.typeValue);
+    }
+
+    @Test
+    public void testNullTypeCoinInfo() {
+        CryptoCoinInfo coinInfo = new CryptoCoinInfo(null, CryptoCoinInfo.Network.MAINNET);
+        Assert.assertSame(coinInfo.getType(), CryptoCoinInfo.Type.BITCOIN);
+    }
+}

--- a/src/test/java/com/sparrowwallet/hummingbird/registry/CryptoCoinInfoTest.java
+++ b/src/test/java/com/sparrowwallet/hummingbird/registry/CryptoCoinInfoTest.java
@@ -18,6 +18,18 @@ public class CryptoCoinInfoTest {
     }
 
     @Test
+    public void testBitcoinTypeCoinInfo() {
+        CryptoCoinInfo coinInfo = new CryptoCoinInfo(CryptoCoinInfo.Type.BITCOIN, CryptoCoinInfo.Network.MAINNET);
+        Assert.assertSame(coinInfo.getType(), CryptoCoinInfo.Type.BITCOIN);
+    }
+
+    @Test
+    public void testEthereumTypeCoinInfo() {
+        CryptoCoinInfo coinInfo = new CryptoCoinInfo(CryptoCoinInfo.Type.ETHEREUM, CryptoCoinInfo.Network.MAINNET);
+        Assert.assertSame(coinInfo.getType(), CryptoCoinInfo.Type.ETHEREUM);
+    }
+
+    @Test
     public void testNullTypeCoinInfo() {
         CryptoCoinInfo coinInfo = new CryptoCoinInfo(null, CryptoCoinInfo.Network.MAINNET);
         Assert.assertSame(coinInfo.getType(), CryptoCoinInfo.Type.BITCOIN);


### PR DESCRIPTION
CryptoCoinInfo was crashing when passing ETHEREUM coin value. Now CryptoCoinInfo can support ETHEREUM value and it is not crashing.


`./gradlew test

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
3 actionable tasks: 1 executed, 2 up-to-date
`